### PR TITLE
Change to leading dot

### DIFF
--- a/rubocop-airbnb/config/rubocop-layout.yml
+++ b/rubocop-airbnb/config/rubocop-layout.yml
@@ -101,7 +101,7 @@ Layout/DefEndAlignment:
 # Use trailing commas, because there are safer in ruby.
 Layout/DotPosition:
   Enabled: true
-  EnforcedStyle: trailing
+  EnforcedStyle: "leading"
 
 # Supports --auto-correct
 Layout/ElseAlignment:


### PR DESCRIPTION
I personally find leading dot easier to parse due to it being instantly apparent the following lines are linked.
Previously:
```
# Valid
Object.
  call_one.
  call_two

# Invalid
Object
  .call_one
  .call_two
```

With this commit:
```
# Valid
Object
  .call_one
  .call_two

# Invalid
# Valid
Object.
  call_one.
  call_two
```

This also helps cut down merge issues as with the existing style guide it requires the previous existing line to add a . to the end